### PR TITLE
Remove stas object from Habit

### DIFF
--- a/src/features/habits/api/index.ts
+++ b/src/features/habits/api/index.ts
@@ -27,7 +27,7 @@ export const fetchHabitStats = async (
 };
 
 export const addHabit = async (
-  habitData: Omit<Habit, "id" | "completed" | "stats">,
+  habitData: Omit<Habit, "id" | "completed">,
 ): Promise<{ message: string; habitId: string }> => {
   const response = await axiosInstance.post<{
     message: string;
@@ -38,7 +38,7 @@ export const addHabit = async (
 
 export const updateHabit = async (
   habitId: string,
-  habitData: Partial<Omit<Habit, "id" | "completed" | "stats">>,
+  habitData: Partial<Omit<Habit, "id" | "completed">>,
 ): Promise<{ message: string; habitId: string }> => {
   const response = await axiosInstance.put<{
     message: string;

--- a/src/features/habits/hooks/useHabits.ts
+++ b/src/features/habits/hooks/useHabits.ts
@@ -22,12 +22,10 @@ interface UseHabitsReturn {
   error: unknown;
   animatingHabitId: string | null;
   mutateHabits: () => Promise<Habit[] | undefined>;
-  addHabit: (
-    habitData: Omit<Habit, "id" | "completed" | "stats">,
-  ) => Promise<void>;
+  addHabit: (habitData: Omit<Habit, "id" | "completed">) => Promise<void>;
   updateHabit: (
     habitId: string,
-    habitData: Partial<Omit<Habit, "id" | "completed" | "stats">>,
+    habitData: Partial<Omit<Habit, "id" | "completed">>,
   ) => Promise<void>;
   deleteHabit: (habitId: string, habitName: string) => Promise<void>;
   toggleHabit: (habitId: string) => Promise<void>;
@@ -67,7 +65,7 @@ export function useHabits(): UseHabitsReturn {
   }, [timeoutId]);
 
   const addHabit = useCallback(
-    async (habitData: Omit<Habit, "id" | "completed" | "stats">) => {
+    async (habitData: Omit<Habit, "id" | "completed">) => {
       try {
         await apiAddHabit(habitData);
         toast({
@@ -90,7 +88,7 @@ export function useHabits(): UseHabitsReturn {
   const updateHabit = useCallback(
     async (
       habitId: string,
-      habitData: Partial<Omit<Habit, "id" | "completed" | "stats">>,
+      habitData: Partial<Omit<Habit, "id" | "completed">>,
     ) => {
       void mutateHabits(
         (currentHabits) =>

--- a/src/features/habits/types/Habit.ts
+++ b/src/features/habits/types/Habit.ts
@@ -1,5 +1,5 @@
-import { Frequency } from '@/features/habits/types/Frequency';
-import HabitsIcons from '@/icons/habits';
+import { Frequency } from "@/features/habits/types/Frequency";
+import HabitsIcons from "@/icons/habits";
 
 export interface Habit {
   id?: string;
@@ -7,9 +7,4 @@ export interface Habit {
   icon: keyof typeof HabitsIcons;
   frequency: Frequency[];
   completed: boolean;
-  stats: {
-    streak: number;
-    totalCompletions: number;
-    lastCompleted: string | null;
-  };
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the habit data model by removing the "stats" property from habits.
  - Updated related functions to allow for the new habit structure without the "stats" property.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->