### PR TITLE
Add maximum file size limit for caching and increase chunk size warning limit in Vite configuration

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,6 +35,7 @@ export default defineConfig({
         globPatterns: ['**/*.{js,css,html,ico,png,svg}'],
         navigateFallback: 'index.html',
         navigateFallbackDenylist: [/^\/api/],
+        maximumFileSizeToCacheInBytes: 3 * 1024 * 1024, // 3MB limit
         runtimeCaching: [
           {
             urlPattern: /^https:\/\/fonts\.googleapis\.com\/.*/i,
@@ -70,6 +71,24 @@ export default defineConfig({
       filename: 'sw.js',
     }),
   ],
+  build: {
+    chunkSizeWarningLimit: 3000, // Increase warning limit to 3MB
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          vendor: ['react', 'react-dom'],
+          ui: [
+            '@radix-ui/react-dialog',
+            '@radix-ui/react-tabs',
+            '@radix-ui/react-toast',
+          ],
+          charts: ['recharts'],
+          icons: ['lucide-react'],
+          clerk: ['@clerk/clerk-react'],
+        },
+      },
+    },
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
- Set maximum file size to cache in bytes to 3MB
- Increase chunk size warning limit to 3MB
- Define manual chunks for better code splitting in Rollup configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized app bundling with smarter chunking to improve startup speed, cache efficiency, and smoother navigation, especially on repeat visits and slow networks.
* **Chores**
  * Tuned PWA caching limits to include more medium-sized assets, enhancing offline access, reducing missed resources, and delivering more reliable updates without excessive re-downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->